### PR TITLE
Avoid constexpr for better compiler compatibility

### DIFF
--- a/FmDecode.cc
+++ b/FmDecode.cc
@@ -82,6 +82,8 @@ void PhaseDiscriminator::process(const IQSampleVector& samples_in,
 
 /* ****************  class PilotPhaseLock  **************** */
 
+const int PilotPhaseLock::pilot_frequency = 19000;
+
 // Construct phase-locked loop.
 PilotPhaseLock::PilotPhaseLock(double freq, double bandwidth, double minsignal)
 {
@@ -250,6 +252,12 @@ void PilotPhaseLock::process(const SampleVector& samples_in,
 
 
 /* ****************  class FmDecoder  **************** */
+
+const double FmDecoder::default_deemphasis    =     50;
+const double FmDecoder::default_bandwidth_if  = 100000;
+const double FmDecoder::default_freq_dev      =  75000;
+const double FmDecoder::default_bandwidth_pcm =  15000;
+const double FmDecoder::pilot_freq            =  19000;
 
 FmDecoder::FmDecoder(double sample_rate_if,
                      double tuning_offset,

--- a/FmDecode.h
+++ b/FmDecode.h
@@ -40,7 +40,7 @@ class PilotPhaseLock
 public:
 
     /** Expected pilot frequency (used for PPS events). */ 
-    static constexpr int pilot_frequency = 19000;
+    static const int pilot_frequency;
 
     /** Timestamp event produced once every 19000 pilot periods. */
     struct PpsEvent
@@ -106,11 +106,11 @@ private:
 class FmDecoder
 {
 public:
-    static constexpr double default_deemphasis    =     50;
-    static constexpr double default_bandwidth_if  = 100000;
-    static constexpr double default_freq_dev      =  75000;
-    static constexpr double default_bandwidth_pcm =  15000;
-    static constexpr double pilot_freq            =  19000;
+    static const double default_deemphasis;
+    static const double default_bandwidth_if;
+    static const double default_freq_dev;
+    static const double default_bandwidth_pcm;
+    static const double pilot_freq;
 
     /**
      * Construct FM decoder.


### PR DESCRIPTION
Using "static constexpr" variables causes compilation problems with some compilers.  Specifically clang(++) on macos in this case.  This compiler (and I assume others) treat a "static constexpr" variable as an r-value, making it ineligible for operations such as std::min().

Changing the variables to "static const" and initializing them in the translation unit (FmDecode.cc) works as expected for a wider range of compilers, including the aforementioned clang(++) on macos.